### PR TITLE
修正文档中的换行问题

### DIFF
--- a/插件编写指南.md
+++ b/插件编写指南.md
@@ -173,6 +173,8 @@ Builtins.SimpleJsonDataReader.writeFileTo(插件名, 数据库文件的名字, �
 
 ## 附录: game_ctrl(GameControl/GameManager) 提供的方法 ##
 WARNING: 以下中文参数并非实际参数, 仅作为参考
+
+```python
 game_ctrl:
     .say_to(玩家选择器/玩家名: str, 消息: str) -> None: 向玩家发送Tellraw消息
     .sendcmd(指令, 是否获取返回值: bool = False, 超时时间(秒) = 30)
@@ -196,3 +198,4 @@ game_ctrl:
     .player_title(目标选择器/玩家名: str, t显信息: str) -> None:对玩家T显
     .player_subtitle(目标选择器/玩家名: str, t显信息: str) -> None:对玩家T显
     .player_actionbar(目标选择器/玩家名: str, t显信息: str) -> None:对玩家T显
+```


### PR DESCRIPTION
底部的未遵循 md的语法,导致渲染错误。改用 ```python ``` 包裹住了 ,或者一行一行换行也可以。